### PR TITLE
Move Software Licensing functions to Integration file

### DIFF
--- a/edd-per-product-emails.php
+++ b/edd-per-product-emails.php
@@ -41,9 +41,9 @@ if ( ! class_exists( 'EDD_Per_Product_Emails' ) ) {
 		public $title = 'EDD Per Product Emails';
 
 		/**
-	    * @var EDD_PPE_Software_Licensing
-	    */
-	    public static $edd_software_licensing;
+		* @var EDD_PPE_Software_Licensing
+		*/
+		public static $edd_software_licensing;
 
 		/**
 		 * Main Instance
@@ -64,7 +64,7 @@ if ( ! class_exists( 'EDD_Per_Product_Emails' ) ) {
 				self::$instance->load_textdomain();
 
 				// Set up integrations
-		        self::$edd_software_licensing = new EDD_PPE_Software_Licensing();
+				self::$edd_software_licensing = new EDD_PPE_Software_Licensing();
 			}
 
 			return self::$instance;
@@ -178,7 +178,7 @@ if ( ! class_exists( 'EDD_Per_Product_Emails' ) ) {
 
 			//Include Integration files
 			require( $this->includes_dir . 'integrations/plugin-software-licenses.php' );
-			
+
 			do_action( 'edd_ppe_include_files' );
 
 			if ( ! is_admin() )

--- a/edd-per-product-emails.php
+++ b/edd-per-product-emails.php
@@ -41,6 +41,11 @@ if ( ! class_exists( 'EDD_Per_Product_Emails' ) ) {
 		public $title = 'EDD Per Product Emails';
 
 		/**
+	    * @var EDD_PPE_Software_Licensing
+	    */
+	    public static $edd_software_licensing;
+
+		/**
 		 * Main Instance
 		 *
 		 * Ensures that only one instance exists in memory at any one
@@ -57,6 +62,9 @@ if ( ! class_exists( 'EDD_Per_Product_Emails' ) ) {
 				self::$instance->setup_actions();
 				self::$instance->licensing();
 				self::$instance->load_textdomain();
+
+				// Set up integrations
+		        self::$edd_software_licensing = new EDD_PPE_Software_Licensing();
 			}
 
 			return self::$instance;
@@ -168,6 +176,9 @@ if ( ! class_exists( 'EDD_Per_Product_Emails' ) ) {
 			require( $this->includes_dir . 'receipt-functions.php' );
 			require( $this->includes_dir . 'email-functions.php' );
 
+			//Include Integration files
+			require( $this->includes_dir . 'integrations/plugin-software-licenses.php' );
+			
 			do_action( 'edd_ppe_include_files' );
 
 			if ( ! is_admin() )

--- a/includes/email-functions.php
+++ b/includes/email-functions.php
@@ -299,17 +299,6 @@ function edd_ppe_test_purchase_receipt( $receipt_id = 0 ) {
 */
 function edd_ppe_email_template_tags( $input, $product_id, $payment_id ) {
 
-	// get license key for the download
-	if( function_exists( 'edd_software_licensing' ) ) {
-
-		$license = edd_software_licensing()->get_license_by_purchase( $payment_id, $product_id );
-
-		if ( $license ) {
-			$license_key = get_post_meta( $license->ID, '_edd_sl_key', true );
-		}
-
-	}
-
 	// download name
 	$download_name = html_entity_decode( get_the_title( $product_id ), ENT_COMPAT, 'UTF-8' );
 
@@ -322,10 +311,7 @@ function edd_ppe_email_template_tags( $input, $product_id, $payment_id ) {
 	// used by the subject line
 	$input = str_replace( '{sitename}', $blog_name, $input );
 
-	// used by the body
-	$input = str_replace( '{license_key}', $license_key, $input );
-
-	return $input;
+	return apply_filters( 'edd_ppe_email_template_tags', $input, $product_id, $payment_id );
 
 }
 
@@ -372,7 +358,6 @@ add_filter( 'edd_email_preview_template_tags', 'edd_ppe_email_preview_template_t
 function edd_ppe_list_custom_email_tags() {
 
 	$tags = '{download_name} - ' . sprintf( __( 'The %s name', 'edd-ppe' ), strtolower( edd_get_label_singular() ) );
-	$tags .= '<br/>{license_key} - ' . sprintf( __( 'Show the license key for the %s', 'edd-ppe' ), strtolower( edd_get_label_singular() ) );
 
-	return $tags;
+	return apply_filters( 'edd_ppe_list_custom_email_tags', $tags );
 }

--- a/includes/integrations/plugin-software-licenses.php
+++ b/includes/integrations/plugin-software-licenses.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Integration functions to make Software Licenses compatible with Per Product Emails
+ *
+ * @package     EDD\PerProductEmails\Functions
+ * @since       1.0.0
+ */
+
+// Exit if accessed directly
+if( !defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Integrates EDD All Access with the EDD Software Licensing extension
+ *
+ * @since v1.1.3
+ */
+class EDD_PPE_Software_Licensing {
+
+	/**
+	 * Get things started
+	 *
+	 * @since  1.1.3
+	 * @return void
+	 */
+	public function __construct() {
+
+		if ( ! class_exists( 'EDD_Software_Licensing' ) ) {
+			return;
+		}
+
+		add_filter( 'edd_ppe_email_template_tags', array( $this, 'replace_license_key_email_tag_with_license_key' ), 10, 3 );
+		add_filter( 'edd_ppe_list_custom_email_tags', array( $this, 'add_license_key_email_tag' ) );
+
+	}
+
+	/**
+	 * Add the note about th ability to add {license_key} to a per product email.
+	 *
+	 * @since       1.1.3
+	 * @param       string $email_tags An HTML string consisting of all the acceptable email tags.
+	 * @return      string $email_tags An HTML string consisting of all the acceptable email tags.
+	 */
+	function add_license_key_email_tag( $email_tags ){
+		$email_tags .= '<br/>{license_key} - ' . sprintf( __( 'Show the license key for the %s', 'edd-ppe' ), strtolower( edd_get_label_singular() ) );
+		return $email_tags;
+	}
+
+	/**
+	 * Add the note about th ability to add {license_key} to a per product email.
+	 *
+	 * @since       1.1.3
+	 * @param       string $input The text in the per product email that is being sent to the customer.
+	 * @param       string $product_id The id of the product that was purchased.
+	 * @param       string $payment_id The id of the payment.
+	 * @return      string $input The text in the per product email that is being sent to the customer.
+	 */
+	function replace_license_key_email_tag_with_license_key( $input, $product_id, $payment_id ){
+
+		// get license key for the download
+		$license = edd_software_licensing()->get_license_by_purchase( $payment_id, $product_id );
+
+		if ( $license ) {
+			$license_key = get_post_meta( $license->ID, '_edd_sl_key', true );
+		}else{
+			$license_key = __( 'No License Key found.', 'edd-ppe' );
+		}
+
+		// used by the body
+		$input = str_replace( '{license_key}', $license_key, $input );
+
+		return $input;
+
+	}
+
+}


### PR DESCRIPTION
This moves all Software Licensing functions to a separate integration file. It also adds the integrations directory and fixes a bug with Software Licensing integration where license key did not exist (https://github.com/easydigitaldownloads/edd-per-product-emails/issues/13)
