### PR TITLE
Use the EDD_SL_License class to get the license key #26

### DIFF
--- a/includes/integrations/plugin-software-licenses.php
+++ b/includes/integrations/plugin-software-licenses.php
@@ -62,7 +62,7 @@ class EDD_PPE_Software_Licensing {
 		$license = edd_software_licensing()->get_license_by_purchase( $payment_id, $product_id );
 
 		if ( $license ) {
-			$license_key = get_post_meta( $license->ID, '_edd_sl_key', true );
+			$license_key = $license->license_key;
 		}else{
 			$license_key = __( 'No License Key found.', 'edd-ppe' );
 		}


### PR DESCRIPTION
Fixes #26 

Proposed Changes:
1. Swaps call to post_meta for using the License Class to get the license key.